### PR TITLE
Fail serial connection flow on configuration timeout

### DIFF
--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -120,7 +120,7 @@ pub async fn send_text(
         channel,
     )?;
 
-    events::dispatch_updated_device(app_handle, device.clone()).map_err(|e| e.to_string())?;
+    events::dispatch_updated_device(&app_handle, device.clone()).map_err(|e| e.to_string())?;
 
     Ok(())
 }
@@ -197,7 +197,7 @@ pub async fn send_waypoint(
         channel,
     )?;
 
-    events::dispatch_updated_device(app_handle, device.clone()).map_err(|e| e.to_string())?;
+    events::dispatch_updated_device(&app_handle, device.clone()).map_err(|e| e.to_string())?;
 
     Ok(())
 }

--- a/src-tauri/src/ipc/events.rs
+++ b/src-tauri/src/ipc/events.rs
@@ -2,8 +2,10 @@ use crate::mesh;
 use log::{debug, trace};
 use tauri::Manager;
 
+use super::ConfigurationStatus;
+
 pub fn dispatch_updated_device(
-    handle: tauri::AppHandle,
+    handle: &tauri::AppHandle,
     device: mesh::device::MeshDevice,
 ) -> tauri::Result<()> {
     debug!("Dispatching updated device");
@@ -16,7 +18,7 @@ pub fn dispatch_updated_device(
 }
 
 pub fn dispatch_updated_edges(
-    handle: tauri::AppHandle,
+    handle: &tauri::AppHandle,
     graph: &mut mesh::device::MeshGraph,
 ) -> tauri::Result<()> {
     debug!("Dispatching updated edges");
@@ -27,4 +29,12 @@ pub fn dispatch_updated_edges(
     debug!("Dispatched updated edges");
 
     Ok(())
+}
+
+pub fn dispatch_configuration_status(
+    handle: &tauri::AppHandle,
+    status: ConfigurationStatus,
+) -> tauri::Result<()> {
+    debug!("Dispatching configuration status");
+    handle.emit_all("configuration_status", status)
 }

--- a/src-tauri/src/ipc/mod.rs
+++ b/src-tauri/src/ipc/mod.rs
@@ -38,3 +38,11 @@ pub struct APMincutStringResults {
     mincut_result: Vec<(u32, u32)>,
     diffcen_result: HashMap<u32, HashMap<u32, HashMap<u32, f64>>>,
 }
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConfigurationStatus {
+    pub port_name: String,
+    pub successful: bool,
+    pub message: Option<String>,
+}

--- a/src-tauri/src/mesh/device/handlers/from_radio/handlers.rs
+++ b/src-tauri/src/mesh/device/handlers/from_radio/handlers.rs
@@ -38,7 +38,9 @@ pub fn handle_config_complete_packet(
     update_result: &mut DeviceUpdateMetadata,
 ) -> Result<(), DeviceUpdateError> {
     device.set_status(SerialDeviceStatus::Configured);
+
     update_result.device_updated = true;
+    update_result.configuration_success = true;
 
     Ok(())
 }

--- a/src-tauri/src/mesh/device/handlers/from_radio/handlers.rs
+++ b/src-tauri/src/mesh/device/handlers/from_radio/handlers.rs
@@ -3,7 +3,7 @@ use app::protobufs;
 use crate::mesh::device::{
     handlers::{DeviceUpdateError, DeviceUpdateMetadata},
     helpers::get_current_time_u32,
-    MeshChannel, MeshDevice,
+    MeshChannel, MeshDevice, SerialDeviceStatus,
 };
 
 pub fn handle_channel_packet(
@@ -28,6 +28,16 @@ pub fn handle_config_packet(
     config: protobufs::Config,
 ) -> Result<(), DeviceUpdateError> {
     device.set_config(config);
+    update_result.device_updated = true;
+
+    Ok(())
+}
+
+pub fn handle_config_complete_packet(
+    device: &mut MeshDevice,
+    update_result: &mut DeviceUpdateMetadata,
+) -> Result<(), DeviceUpdateError> {
+    device.set_status(SerialDeviceStatus::Configured);
     update_result.device_updated = true;
 
     Ok(())

--- a/src-tauri/src/mesh/device/handlers/from_radio/mod.rs
+++ b/src-tauri/src/mesh/device/handlers/from_radio/mod.rs
@@ -18,9 +18,7 @@ impl MeshDevice {
                 handlers::handle_config_packet(self, &mut update_result, config)?;
             }
             protobufs::from_radio::PayloadVariant::ConfigCompleteId(_c) => {
-                return Err(DeviceUpdateError::RadioMessageNotSupported(
-                    "config complete".into(),
-                ));
+                handlers::handle_config_complete_packet(self, &mut update_result)?;
             }
             protobufs::from_radio::PayloadVariant::LogRecord(_l) => {
                 return Err(DeviceUpdateError::RadioMessageNotSupported(

--- a/src-tauri/src/mesh/device/handlers/mod.rs
+++ b/src-tauri/src/mesh/device/handlers/mod.rs
@@ -21,6 +21,7 @@ impl NotificationConfig {
 pub struct DeviceUpdateMetadata {
     pub device_updated: bool,
     pub regenerate_graph: bool,
+    pub configuration_success: bool,
     pub notification_config: Option<NotificationConfig>,
 }
 

--- a/src-tauri/src/mesh/device/mod.rs
+++ b/src-tauri/src/mesh/device/mod.rs
@@ -13,13 +13,13 @@ pub mod state;
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub enum SerialDeviceStatus {
-    Restarting,
-    Disconnected,
-    Connecting,
-    Reconnecting,
-    Connected,
-    Configuring,
-    Configured,
+    Restarting,   // unused
+    Disconnected, // no attempt or failure to connect
+    Connecting,   // connection initialized, not yet configured
+    Reconnecting, // unused
+    Connected,    // successful serial connection and device configuration, UI notified
+    Configuring,  // configuration in process
+    Configured,   // configured but UI not yet notified
 }
 
 impl Default for SerialDeviceStatus {

--- a/src-tauri/src/mesh/device/mod.rs
+++ b/src-tauri/src/mesh/device/mod.rs
@@ -10,9 +10,9 @@ pub mod handlers;
 pub mod helpers;
 pub mod state;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
-pub enum MeshDeviceStatus {
+pub enum SerialDeviceStatus {
     Restarting,
     Disconnected,
     Connecting,
@@ -22,9 +22,9 @@ pub enum MeshDeviceStatus {
     Configured,
 }
 
-impl Default for MeshDeviceStatus {
+impl Default for SerialDeviceStatus {
     fn default() -> Self {
-        MeshDeviceStatus::Disconnected
+        SerialDeviceStatus::Disconnected
     }
 }
 
@@ -125,14 +125,14 @@ pub struct ChannelMessageWithState {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MeshDevice {
-    pub config_id: u32,           // unique identifier for configuration flow packets
-    pub ready: bool,              // is device configured to participate in mesh
-    pub status: MeshDeviceStatus, // current config status of device
+    pub config_id: u32,             // unique identifier for configuration flow packets
+    pub ready: bool,                // is device configured to participate in mesh
+    pub status: SerialDeviceStatus, // current config status of device
     pub channels: HashMap<u32, MeshChannel>, // channels device is able to access
     pub config: protobufs::LocalConfig, // local-only device configuration
     pub my_node_info: protobufs::MyNodeInfo, // debug information specific to device
     pub nodes: HashMap<u32, MeshNode>, // network devices this device has communicated with
-    pub region_unset: bool,       // flag for whether device has an unset LoRa region
+    pub region_unset: bool,         // flag for whether device has an unset LoRa region
     pub device_metrics: protobufs::DeviceMetrics, // information about functioning of device (e.g. battery level)
     pub waypoints: HashMap<u32, protobufs::Waypoint>, // updatable GPS positions managed by this device
     pub neighbors: HashMap<u32, protobufs::NeighborInfo>, //updated packets from each node containing their neighbors

--- a/src-tauri/src/mesh/device/state.rs
+++ b/src-tauri/src/mesh/device/state.rs
@@ -5,9 +5,9 @@ use log::{debug, trace};
 
 use super::helpers::get_current_time_u32;
 use super::{
-    ChannelMessagePayload, ChannelMessageWithState, MeshChannel, MeshDevice, MeshDeviceStatus,
-    MeshGraph, MeshNode, MeshNodeDeviceMetrics, MeshNodeEnvironmentMetrics, NeighborInfoPacket,
-    PositionPacket, TelemetryPacket, TextPacket, UserPacket, WaypointPacket,
+    ChannelMessagePayload, ChannelMessageWithState, MeshChannel, MeshDevice, MeshGraph, MeshNode,
+    MeshNodeDeviceMetrics, MeshNodeEnvironmentMetrics, NeighborInfoPacket, PositionPacket,
+    SerialDeviceStatus, TelemetryPacket, TextPacket, UserPacket, WaypointPacket,
 };
 
 use crate::constructors::init::init_edge_map::init_edge_map;
@@ -20,7 +20,7 @@ impl MeshDevice {
         self.ready = ready;
     }
 
-    pub fn set_status(&mut self, status: MeshDeviceStatus) {
+    pub fn set_status(&mut self, status: SerialDeviceStatus) {
         debug!("Set status: {:?}", status);
         self.status = status;
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Routes, Route, Outlet } from "react-router-dom";
 import SplashScreen from "@components/SplashScreen/SplashScreen";
 import Sidebar from "@components/Sidebar/Sidebar";
 
-import HomePage from "@components/pages/HomePage";
+import MapPage from "@components/pages/MapPage";
 import FallbackPage from "@components/pages/FallbackPage";
 import SerialConnectPage from "@components/pages/SerialConnectPage";
 import MessagingPage from "@components/pages/MessagingPage";
@@ -50,7 +50,7 @@ const App = () => {
 
       <Routes>
         <Route path="/" element={<AppWrapper />}>
-          <Route index element={<HomePage />} />
+          <Route index element={<MapPage />} />
           <Route path={AppRoutes.MESSAGING} element={<MessagingPage />} />
 
           <Route

--- a/src/components/Onboard/SerialPortOption.tsx
+++ b/src/components/Onboard/SerialPortOption.tsx
@@ -6,11 +6,11 @@ import {
   EllipsisHorizontalCircleIcon,
 } from "@heroicons/react/24/outline";
 
-import type { IRequestState } from "@features/requests/requestReducer";
+import type { RequestStatus } from "@features/requests/requestReducer";
 
 export interface ISerialPortOptions {
   name: string;
-  connectionState: IRequestState;
+  connectionState: RequestStatus;
   onClick: (portName: string) => void;
 }
 

--- a/src/components/pages/MapPage.tsx
+++ b/src/components/pages/MapPage.tsx
@@ -1,10 +1,10 @@
 import React from "react";
 import { MapView } from "@components/Map/MapView";
 
-const HomePage = () => (
+const MapPage = () => (
   <div className="h-screen flex-1 bg-gray-100">
     <MapView />
   </div>
 );
 
-export default HomePage;
+export default MapPage;

--- a/src/components/pages/SerialConnectPage.tsx
+++ b/src/components/pages/SerialConnectPage.tsx
@@ -7,6 +7,7 @@ import Hero_Image from "@app/assets/onboard_hero_image.jpg";
 import Meshtastic_Logo from "@app/assets/Mesh_Logo_Black.png";
 import SerialPortOption from "@components/Onboard/SerialPortOption";
 
+import { selectConnectionStatus } from "@features/connection/connectionSelectors";
 import {
   requestAutoConnectPort,
   requestAvailablePorts,
@@ -16,11 +17,7 @@ import {
   selectAutoConnectPort,
   selectAvailablePorts,
 } from "@features/device/deviceSelectors";
-import { selectRequestStateByName } from "@features/requests/requestSelectors";
-import {
-  IRequestState,
-  requestSliceActions,
-} from "@features/requests/requestReducer";
+import { requestSliceActions } from "@features/requests/requestReducer";
 
 import "@components/SplashScreen/SplashScreen.css";
 
@@ -36,8 +33,8 @@ const SerialConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const [selectedPortName, setSelectedPortName] = useState("");
   const [isScreenActive, setScreenActive] = useState(true);
 
-  const activePortState: IRequestState = useSelector(
-    selectRequestStateByName(requestConnectToDevice.type)
+  const activePortState = useSelector(
+    selectConnectionStatus(selectedPortName)
   ) ?? { status: "IDLE" };
 
   const requestPorts = () => {

--- a/src/features/connection/connectionSelectors.ts
+++ b/src/features/connection/connectionSelectors.ts
@@ -1,0 +1,6 @@
+import type { RootState } from "@app/store";
+import type { RequestStatus } from "@features/requests/requestReducer";
+
+export const selectConnectionStatus =
+  (portName: string) => (state: RootState): RequestStatus | null =>
+    state.connection.connections?.[portName] ?? null;

--- a/src/features/connection/connectionSlice.ts
+++ b/src/features/connection/connectionSlice.ts
@@ -1,0 +1,26 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import type { RequestStatus } from "@features/requests/requestReducer";
+
+export interface IConnectionState {
+  connections: Record<string, RequestStatus>; // portName to state
+}
+
+export const initialConnectionState: IConnectionState = {
+  connections: {},
+};
+
+export const connectionSlice = createSlice({
+  name: "connection",
+  initialState: initialConnectionState,
+  reducers: {
+    setConnectionState: (
+      state,
+      action: PayloadAction<{ portName: string; status: RequestStatus }>,
+    ) => {
+      state.connections[action.payload.portName] = action.payload.status;
+    },
+  },
+});
+
+export const { actions: connectionSliceActions, reducer: connectionReducer } =
+  connectionSlice;

--- a/src/features/device/deviceConnectionHandlerSagas.ts
+++ b/src/features/device/deviceConnectionHandlerSagas.ts
@@ -3,6 +3,7 @@ import { call, put, take } from "redux-saga/effects";
 import { listen } from "@tauri-apps/api/event";
 
 import type { MeshDevice } from "@bindings/MeshDevice";
+import { connectionSliceActions } from "@features/connection/connectionSlice";
 import { deviceSliceActions } from "@features/device/deviceSlice";
 import { requestDisconnectFromDevice } from "@features/device/deviceActions";
 import { mapSliceActions } from "@features/map/mapSlice";
@@ -10,6 +11,7 @@ import { mapSliceActions } from "@features/map/mapSlice";
 export type DeviceUpdateChannel = EventChannel<MeshDevice>;
 export type DeviceDisconnectChannel = EventChannel<string>;
 export type GraphUpdateChannel = EventChannel<GeoJSON.FeatureCollection>;
+export type ConfigStatusChannel = EventChannel<boolean>;
 
 function* handleSagaError(error: unknown) {
   yield put({ type: "GENERAL_ERROR", payload: error });
@@ -58,7 +60,7 @@ export const createDeviceDisconnectChannel = (): DeviceDisconnectChannel => {
 };
 
 export function* handleDeviceDisconnectChannel(
-  channel: DeviceDisconnectChannel
+  channel: DeviceDisconnectChannel,
 ) {
   try {
     while (true) {
@@ -93,6 +95,45 @@ export function* handleGraphUpdateChannel(channel: GraphUpdateChannel) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const edgeFeatures: GeoJSON.FeatureCollection = yield take(channel);
       yield put(mapSliceActions.setEdgesFeatureCollection(edgeFeatures));
+    }
+  } catch (error) {
+    yield call(handleSagaError, error);
+  }
+}
+
+export const createConfigStatusChannel = (): ConfigStatusChannel => {
+  return eventChannel((emitter) => {
+    listen<boolean>("configuration_status", (event) => {
+      emitter(event.payload);
+    })
+      // .then((unlisten) => {
+      //   return unlisten;
+      // })
+      .catch(console.error);
+
+    // TODO UNLISTEN
+    return () => null;
+  });
+};
+
+export function* handleConfigStatusChannel(channel: ConfigStatusChannel) {
+  try {
+    while (true) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const { successful, portName, message }: {
+        successful: boolean;
+        portName: string;
+        message: string | null;
+      } = yield take(channel);
+
+      yield put(
+        connectionSliceActions.setConnectionState({
+          portName,
+          status: successful
+            ? { status: "SUCCESSFUL" }
+            : { status: "FAILED", message: message ?? "" },
+        }),
+      );
     }
   } catch (error) {
     yield call(handleSagaError, error);

--- a/src/features/requests/requestReducer.ts
+++ b/src/features/requests/requestReducer.ts
@@ -1,13 +1,13 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 
-export type IRequestState =
+export type RequestStatus =
   | { status: "IDLE" }
   | { status: "PENDING" }
   | { status: "SUCCESSFUL" }
   | { status: "FAILED"; message: string };
 
 export interface IRequestReducerState {
-  status: Record<string, IRequestState>;
+  status: Record<string, RequestStatus>;
 }
 
 const InitialRequestState: IRequestReducerState = { status: {} };
@@ -27,7 +27,7 @@ export const requestSlice = createSlice({
     },
     setRequestFailed: (
       state,
-      action: PayloadAction<{ name: string; message: string }>
+      action: PayloadAction<{ name: string; message: string }>,
     ) => {
       state.status[action.payload.name] = {
         status: "FAILED",

--- a/src/features/requests/requestSelectors.ts
+++ b/src/features/requests/requestSelectors.ts
@@ -1,7 +1,6 @@
 import type { RootState } from "@app/store";
-import type { IRequestState } from "./requestReducer";
+import type { RequestStatus } from "@features/requests/requestReducer";
 
 export const selectRequestStateByName =
-  (name: string) =>
-  (state: RootState): IRequestState | null =>
+  (name: string) => (state: RootState): RequestStatus | null =>
     state.requests.status?.[name] ?? null;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import createSagaMiddleware from "redux-saga";
 import { logger } from "redux-logger";
 
 import { algorithmsReducer } from "@features/algorithms/algorithmsSlice";
+import { connectionReducer } from "@features/connection/connectionSlice";
 import { deviceReducer } from "@features/device/deviceSlice";
 import { requestReducer } from "@features/requests/requestReducer";
 import { mapReducer } from "@features/map/mapSlice";
@@ -15,6 +16,7 @@ const middleware = [sagaMiddleware, logger];
 export const store = configureStore({
   reducer: {
     algorithms: algorithmsReducer,
+    connection: connectionReducer,
     devices: deviceReducer,
     map: mapReducer,
     requests: requestReducer,


### PR DESCRIPTION
This PR changes the condition for a successful serial connection within the `SerialConnectPage` flow. Currently all that is required to "successfully" connect to a serial device is for the `connect_to_serial_port` command to succeed. The issue with this is that, in the event that receiving configuration data from the serial device fails (device config, module config, channels), this failure will be silent to the user. This PR changes this "success" requirement to receiving a `ConfigCompleteId` packet from the serial device within a set timeout period (currently 1500ms). If this timeout is reached, the device will fail to connect and this failure will display on the `SerialConnectPage` UI in a user-readable manner.

![Screenshot_20230409_144339](https://user-images.githubusercontent.com/46639306/230790929-e4f050f1-19d0-42a3-bb4f-c83bb9f7130d.png)

This change relies on the `SerialDeviceStatus` struct, shown below:

```rust
pub enum SerialDeviceStatus {
    Restarting,   // unused
    Disconnected, // no attempt or failure to connect
    Connecting,   // connection initialized, not yet configured
    Reconnecting, // unused
    Connected,    // successful serial connection and device configuration, UI notified
    Configuring,  // configuration in process
    Configured,   // configured but UI not yet notified
}
```
When a device is first created, it will start in the `Disconnected` state. When a serial connection is initialized to this device, it will move to the `Connecting` state. Once configuration is attempted, the device will move to the `Configuring` state and a timeout (currently 1500ms) will start. If the device does not receive a `ConfigCompleteId` packet within this timeout window, the device will notify the UI of the failure and will move back into the `Disconnected` state. If this packet is received within the timeout window, the device will move into the  `Configured` state. It will stay in this state until the UI layer is notified via the `"configuration_status"` event, at which point it will transition into the `Connected` state.

This PR is dependent on #359. 

