### PR TITLE
Added failure case for device misconfig or existing port connection

### DIFF
--- a/src/components/Onboard/SerialPortOption.tsx
+++ b/src/components/Onboard/SerialPortOption.tsx
@@ -73,8 +73,6 @@ const SerialPortOption = ({
               </h1>
             </div>
             <h1 className="pl-6 pr-2 ml-4 text-sm leading-5 font-light text-red-600 mt-0.5">
-              Failed to connect with error:
-              <br />
               <i>{connectionState.message}</i>
             </h1>
           </div>

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -166,6 +166,16 @@ function* connectToDeviceWorker(
       })
     );
 
+    yield put(
+      connectionSliceActions.setConnectionState({
+        portName: action.payload.portName,
+        status: {
+          status: "FAILED",
+          message: (error as CommandError).message,
+        },
+      })
+    );
+
     if (subscribeTask) {
       yield cancel(subscribeTask);
     }


### PR DESCRIPTION
This PR adds a new `ConnectionError` struct to the Rust `connect_to_serial_port` command, as defined below.

```rust
pub enum ConnectionError {
    PortOpenError,
    ConfigurationError,
}
```

This allows for the explicit handling of "port busy" and "failed to configure" errors, which was not possible before. This PR also updates the `connectToDeviceWorker` generator to correctly label a pending connection as closed on error.

Closes #381 