### PR TITLE
enhancement: add tooltip text to sidebar icons

### DIFF
--- a/src/components/DefaultTooltip.tsx
+++ b/src/components/DefaultTooltip.tsx
@@ -5,13 +5,16 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 export interface IDefaultTooltipProps {
   text: string;
   children: ReactNode;
+  deactivated: boolean;
 }
 
-const DefaultTooltip = ({ text, children }: IDefaultTooltipProps) => {
+const DefaultTooltip = ({ text, children, deactivated }: IDefaultTooltipProps) => {
+  if(deactivated)  return <>{children}</>; 
   return (
     <Tooltip.Provider>
-      <Tooltip.Root delayDuration={300}>
-        <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
+      <Tooltip.Root
+       delayDuration={300}>
+        <Tooltip.Trigger  asChild>{children}</Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
             className="px-3 py-1.5 shadow-lg rounded-lg bg-white border border-gray-200 text-xs font-normal text-gray-400"

--- a/src/components/DefaultTooltip.tsx
+++ b/src/components/DefaultTooltip.tsx
@@ -5,16 +5,19 @@ import * as Tooltip from "@radix-ui/react-tooltip";
 export interface IDefaultTooltipProps {
   text: string;
   children: ReactNode;
-  deactivated: boolean;
+  deactivated?: boolean;
 }
 
-const DefaultTooltip = ({ text, children, deactivated }: IDefaultTooltipProps) => {
-  if(deactivated)  return <>{children}</>; 
+const DefaultTooltip = ({
+  text,
+  children,
+  deactivated,
+}: IDefaultTooltipProps) => {
+  if (deactivated) return <>{children}</>;
   return (
     <Tooltip.Provider>
-      <Tooltip.Root
-       delayDuration={300}>
-        <Tooltip.Trigger  asChild>{children}</Tooltip.Trigger>
+      <Tooltip.Root delayDuration={300}>
+        <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
             className="px-3 py-1.5 shadow-lg rounded-lg bg-white border border-gray-200 text-xs font-normal text-gray-400"

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -41,20 +41,23 @@ const Sidebar = () => {
       <div className="flex flex-col flex-1 justify-between px-4 pt-4 pb-1">
         <div className="flex flex-col gap-6 mb-6">
           <SidebarTab title="Overview" isSidebarExpanded={isSidebarExpanded}>
-            <DefaultTooltip text="Messaging">
+            <DefaultTooltip text="Messaging" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Messaging"
-                isActive={location.pathname === AppRoutes.MESSAGING}
+                isActive={location.pathname === AppRoutes.MESSAGING }
                 isSidebarExpanded={isSidebarExpanded}
                 onClick={() => navigateTo(AppRoutes.MESSAGING)}
               >
                 <MessagesSquare strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
           </SidebarTab>
 
           <SidebarTab title="Network" isSidebarExpanded={isSidebarExpanded}>
-            <DefaultTooltip text="Manage Nodes">
+            <DefaultTooltip text="Manage Nodes" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Manage Nodes"
                 isActive={location.pathname === AppRoutes.MANAGE_NODES}
@@ -63,8 +66,10 @@ const Sidebar = () => {
               >
                 <RadioTower strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
-            <DefaultTooltip text="Manage Waypoints">
+            <DefaultTooltip text="Manage Waypoints" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Manage Waypoints"
                 isActive={location.pathname === AppRoutes.MANAGE_WAYPOINTS}
@@ -73,6 +78,7 @@ const Sidebar = () => {
               >
                 <MapPin strokeWidth={1.5} className="w-6 h-6 stroke-3/2" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
           </SidebarTab>
 
@@ -80,7 +86,8 @@ const Sidebar = () => {
             title="Configuration"
             isSidebarExpanded={isSidebarExpanded}
           >
-            <DefaultTooltip text="Configure Radio">
+            <DefaultTooltip text="Configure Radio" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Configure Radio"
                 isActive={location.pathname.includes(AppRoutes.CONFIGURE_RADIO)}
@@ -89,9 +96,11 @@ const Sidebar = () => {
               >
                 <Router strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
 
-            <DefaultTooltip text="Configure Modules">
+            <DefaultTooltip text="Configure Modules" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Configure Modules"
                 isActive={location.pathname.includes(
@@ -102,9 +111,11 @@ const Sidebar = () => {
               >
                 <Component strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
 
-            <DefaultTooltip text="Configure Channels">
+            <DefaultTooltip text="Configure Channels" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Configure Channels"
                 isActive={location.pathname.includes(
@@ -115,13 +126,15 @@ const Sidebar = () => {
               >
                 <Mails strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
           </SidebarTab>
         </div>
 
         <div className="">
           <SidebarTab title="Settings" isSidebarExpanded={isSidebarExpanded}>
-            <DefaultTooltip text="Application State">
+            <DefaultTooltip text="Application State" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Application State"
                 isActive={location.pathname === AppRoutes.APPLICATION_STATE}
@@ -130,9 +143,11 @@ const Sidebar = () => {
               >
                 <FileDigit strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
 
-            <DefaultTooltip text="Application Settings">
+            <DefaultTooltip text="Application Settings" deactivated={isSidebarExpanded}>
+              <button>
               <SidebarIcon
                 name="Application Settings"
                 isActive={location.pathname === AppRoutes.APPLICATION_SETTINGS}
@@ -141,11 +156,13 @@ const Sidebar = () => {
               >
                 <Settings strokeWidth={1.5} className="w-6 h-6" />
               </SidebarIcon>
+              </button>
             </DefaultTooltip>
           </SidebarTab>
 
           <hr className="border-gray-100" />
-          <DefaultTooltip text="Collapse Sidebar">
+          <DefaultTooltip text="Collapse Sidebar" deactivated={isSidebarExpanded}>
+            <button>
             <SidebarIcon
               name="Collapse Sidebar"
               isActive={false}
@@ -158,6 +175,7 @@ const Sidebar = () => {
                 <ChevronsRight strokeWidth={1.5} className="w-6 h-6" />
               )}
             </SidebarIcon>
+            </button>
           </DefaultTooltip>
         </div>
       </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -22,6 +22,7 @@ import SidebarTab from "@components/Sidebar/SidebarTab";
 import { AppRoutes } from "@utils/routing";
 
 import "@components/Sidebar/Sidebar.css";
+import DefaultTooltip from "@components/DefaultTooltip";
 
 const Sidebar = () => {
   const [isSidebarExpanded, setSidebarExpanded] = useState(true);
@@ -40,115 +41,124 @@ const Sidebar = () => {
       <div className="flex flex-col flex-1 justify-between px-4 pt-4 pb-1">
         <div className="flex flex-col gap-6 mb-6">
           <SidebarTab title="Overview" isSidebarExpanded={isSidebarExpanded}>
-            <SidebarIcon
-              name="View Map"
-              isActive={location.pathname === AppRoutes.MAP}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.MAP)}
-            >
-              <Map strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
-
-            <SidebarIcon
-              name="Messaging"
-              isActive={location.pathname === AppRoutes.MESSAGING}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.MESSAGING)}
-            >
-              <MessagesSquare strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
+            <DefaultTooltip text="Messaging">
+              <SidebarIcon
+                name="Messaging"
+                isActive={location.pathname === AppRoutes.MESSAGING}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.MESSAGING)}
+              >
+                <MessagesSquare strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
           </SidebarTab>
 
           <SidebarTab title="Network" isSidebarExpanded={isSidebarExpanded}>
-            <SidebarIcon
-              name="Manage Nodes"
-              isActive={location.pathname === AppRoutes.MANAGE_NODES}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.MANAGE_NODES)}
-            >
-              <RadioTower strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
-
-            <SidebarIcon
-              name="Manage Waypoints"
-              isActive={location.pathname === AppRoutes.MANAGE_WAYPOINTS}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.MANAGE_WAYPOINTS)}
-            >
-              <MapPin strokeWidth={1.5} className="w-6 h-6 stroke-3/2" />
-            </SidebarIcon>
+            <DefaultTooltip text="Manage Nodes">
+              <SidebarIcon
+                name="Manage Nodes"
+                isActive={location.pathname === AppRoutes.MANAGE_NODES}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.MANAGE_NODES)}
+              >
+                <RadioTower strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
+            <DefaultTooltip text="Manage Waypoints">
+              <SidebarIcon
+                name="Manage Waypoints"
+                isActive={location.pathname === AppRoutes.MANAGE_WAYPOINTS}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.MANAGE_WAYPOINTS)}
+              >
+                <MapPin strokeWidth={1.5} className="w-6 h-6 stroke-3/2" />
+              </SidebarIcon>
+            </DefaultTooltip>
           </SidebarTab>
 
           <SidebarTab
             title="Configuration"
             isSidebarExpanded={isSidebarExpanded}
           >
-            <SidebarIcon
-              name="Configure Radio"
-              isActive={location.pathname.includes(AppRoutes.CONFIGURE_RADIO)}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.CONFIGURE_RADIO)}
-            >
-              <Router strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
+            <DefaultTooltip text="Configure Radio">
+              <SidebarIcon
+                name="Configure Radio"
+                isActive={location.pathname.includes(AppRoutes.CONFIGURE_RADIO)}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.CONFIGURE_RADIO)}
+              >
+                <Router strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
 
-            <SidebarIcon
-              name="Configure Modules"
-              isActive={location.pathname.includes(AppRoutes.CONFIGURE_PLUGINS)}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.CONFIGURE_PLUGINS)}
-            >
-              <Component strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
+            <DefaultTooltip text="Configure Modules">
+              <SidebarIcon
+                name="Configure Modules"
+                isActive={location.pathname.includes(
+                  AppRoutes.CONFIGURE_PLUGINS
+                )}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.CONFIGURE_PLUGINS)}
+              >
+                <Component strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
 
-            <SidebarIcon
-              name="Configure Channels"
-              isActive={location.pathname.includes(
-                AppRoutes.CONFIGURE_CHANNELS
-              )}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.CONFIGURE_CHANNELS)}
-            >
-              <Mails strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
+            <DefaultTooltip text="Configure Channels">
+              <SidebarIcon
+                name="Configure Channels"
+                isActive={location.pathname.includes(
+                  AppRoutes.CONFIGURE_CHANNELS
+                )}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.CONFIGURE_CHANNELS)}
+              >
+                <Mails strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
           </SidebarTab>
         </div>
 
         <div className="">
           <SidebarTab title="Settings" isSidebarExpanded={isSidebarExpanded}>
-            <SidebarIcon
-              name="Application State"
-              isActive={location.pathname === AppRoutes.APPLICATION_STATE}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.APPLICATION_STATE)}
-            >
-              <FileDigit strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
+            <DefaultTooltip text="Application State">
+              <SidebarIcon
+                name="Application State"
+                isActive={location.pathname === AppRoutes.APPLICATION_STATE}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.APPLICATION_STATE)}
+              >
+                <FileDigit strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
 
-            <SidebarIcon
-              name="Application Settings"
-              isActive={location.pathname === AppRoutes.APPLICATION_SETTINGS}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => navigateTo(AppRoutes.APPLICATION_SETTINGS)}
-            >
-              <Settings strokeWidth={1.5} className="w-6 h-6" />
-            </SidebarIcon>
+            <DefaultTooltip text="Application Settings">
+              <SidebarIcon
+                name="Application Settings"
+                isActive={location.pathname === AppRoutes.APPLICATION_SETTINGS}
+                isSidebarExpanded={isSidebarExpanded}
+                onClick={() => navigateTo(AppRoutes.APPLICATION_SETTINGS)}
+              >
+                <Settings strokeWidth={1.5} className="w-6 h-6" />
+              </SidebarIcon>
+            </DefaultTooltip>
           </SidebarTab>
 
           <hr className="border-gray-100" />
-
-          <SidebarIcon
-            name="Collapse Sidebar"
-            isActive={false}
-            isSidebarExpanded={isSidebarExpanded}
-            onClick={() => setSidebarExpanded(!isSidebarExpanded)}
-          >
-            {isSidebarExpanded ? (
-              <ChevronsLeft strokeWidth={1.5} className="w-6 h-6" />
-            ) : (
-              <ChevronsRight strokeWidth={1.5} className="w-6 h-6" />
-            )}
-          </SidebarIcon>
+          <DefaultTooltip text="Collapse Sidebar">
+            <SidebarIcon
+              name="Collapse Sidebar"
+              isActive={false}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => setSidebarExpanded(!isSidebarExpanded)}
+            >
+              {isSidebarExpanded ? (
+                <ChevronsLeft strokeWidth={1.5} className="w-6 h-6" />
+              ) : (
+                <ChevronsRight strokeWidth={1.5} className="w-6 h-6" />
+              )}
+            </SidebarIcon>
+          </DefaultTooltip>
         </div>
       </div>
     </div>

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -41,142 +41,106 @@ const Sidebar = () => {
       <div className="flex flex-col flex-1 justify-between px-4 pt-4 pb-1">
         <div className="flex flex-col gap-6 mb-6">
           <SidebarTab title="Overview" isSidebarExpanded={isSidebarExpanded}>
-            <DefaultTooltip text="Messaging" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Messaging"
-                isActive={location.pathname === AppRoutes.MESSAGING }
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.MESSAGING)}
-              >
-                <MessagesSquare strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Messaging"
+              isActive={location.pathname === AppRoutes.MESSAGING}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.MESSAGING)}
+            >
+              <MessagesSquare strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
           </SidebarTab>
 
           <SidebarTab title="Network" isSidebarExpanded={isSidebarExpanded}>
-            <DefaultTooltip text="Manage Nodes" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Manage Nodes"
-                isActive={location.pathname === AppRoutes.MANAGE_NODES}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.MANAGE_NODES)}
-              >
-                <RadioTower strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
-            <DefaultTooltip text="Manage Waypoints" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Manage Waypoints"
-                isActive={location.pathname === AppRoutes.MANAGE_WAYPOINTS}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.MANAGE_WAYPOINTS)}
-              >
-                <MapPin strokeWidth={1.5} className="w-6 h-6 stroke-3/2" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Manage Nodes"
+              isActive={location.pathname === AppRoutes.MANAGE_NODES}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.MANAGE_NODES)}
+            >
+              <RadioTower strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
+
+            <SidebarIcon
+              name="Manage Waypoints"
+              isActive={location.pathname === AppRoutes.MANAGE_WAYPOINTS}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.MANAGE_WAYPOINTS)}
+            >
+              <MapPin strokeWidth={1.5} className="w-6 h-6 stroke-3/2" />
+            </SidebarIcon>
           </SidebarTab>
 
           <SidebarTab
             title="Configuration"
             isSidebarExpanded={isSidebarExpanded}
           >
-            <DefaultTooltip text="Configure Radio" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Configure Radio"
-                isActive={location.pathname.includes(AppRoutes.CONFIGURE_RADIO)}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.CONFIGURE_RADIO)}
-              >
-                <Router strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Configure Radio"
+              isActive={location.pathname.includes(AppRoutes.CONFIGURE_RADIO)}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.CONFIGURE_RADIO)}
+            >
+              <Router strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
 
-            <DefaultTooltip text="Configure Modules" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Configure Modules"
-                isActive={location.pathname.includes(
-                  AppRoutes.CONFIGURE_PLUGINS
-                )}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.CONFIGURE_PLUGINS)}
-              >
-                <Component strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Configure Modules"
+              isActive={location.pathname.includes(AppRoutes.CONFIGURE_PLUGINS)}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.CONFIGURE_PLUGINS)}
+            >
+              <Component strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
 
-            <DefaultTooltip text="Configure Channels" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Configure Channels"
-                isActive={location.pathname.includes(
-                  AppRoutes.CONFIGURE_CHANNELS
-                )}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.CONFIGURE_CHANNELS)}
-              >
-                <Mails strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Configure Channels"
+              isActive={location.pathname.includes(
+                AppRoutes.CONFIGURE_CHANNELS
+              )}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.CONFIGURE_CHANNELS)}
+            >
+              <Mails strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
           </SidebarTab>
         </div>
 
         <div className="">
           <SidebarTab title="Settings" isSidebarExpanded={isSidebarExpanded}>
-            <DefaultTooltip text="Application State" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Application State"
-                isActive={location.pathname === AppRoutes.APPLICATION_STATE}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.APPLICATION_STATE)}
-              >
-                <FileDigit strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Application State"
+              isActive={location.pathname === AppRoutes.APPLICATION_STATE}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.APPLICATION_STATE)}
+            >
+              <FileDigit strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
 
-            <DefaultTooltip text="Application Settings" deactivated={isSidebarExpanded}>
-              <button>
-              <SidebarIcon
-                name="Application Settings"
-                isActive={location.pathname === AppRoutes.APPLICATION_SETTINGS}
-                isSidebarExpanded={isSidebarExpanded}
-                onClick={() => navigateTo(AppRoutes.APPLICATION_SETTINGS)}
-              >
-                <Settings strokeWidth={1.5} className="w-6 h-6" />
-              </SidebarIcon>
-              </button>
-            </DefaultTooltip>
+            <SidebarIcon
+              name="Application Settings"
+              isActive={location.pathname === AppRoutes.APPLICATION_SETTINGS}
+              isSidebarExpanded={isSidebarExpanded}
+              onClick={() => navigateTo(AppRoutes.APPLICATION_SETTINGS)}
+            >
+              <Settings strokeWidth={1.5} className="w-6 h-6" />
+            </SidebarIcon>
           </SidebarTab>
 
           <hr className="border-gray-100" />
-          <DefaultTooltip text="Collapse Sidebar" deactivated={isSidebarExpanded}>
-            <button>
-            <SidebarIcon
-              name="Collapse Sidebar"
-              isActive={false}
-              isSidebarExpanded={isSidebarExpanded}
-              onClick={() => setSidebarExpanded(!isSidebarExpanded)}
-            >
-              {isSidebarExpanded ? (
-                <ChevronsLeft strokeWidth={1.5} className="w-6 h-6" />
-              ) : (
-                <ChevronsRight strokeWidth={1.5} className="w-6 h-6" />
-              )}
-            </SidebarIcon>
-            </button>
-          </DefaultTooltip>
+
+          <SidebarIcon
+            name="Collapse Sidebar"
+            isActive={false}
+            isSidebarExpanded={isSidebarExpanded}
+            onClick={() => setSidebarExpanded(!isSidebarExpanded)}
+          >
+            {isSidebarExpanded ? (
+              <ChevronsLeft strokeWidth={1.5} className="w-6 h-6" />
+            ) : (
+              <ChevronsRight strokeWidth={1.5} className="w-6 h-6" />
+            )}
+          </SidebarIcon>
         </div>
       </div>
     </div>

--- a/src/components/Sidebar/SidebarIcon.tsx
+++ b/src/components/Sidebar/SidebarIcon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ReactNode, forwardRef } from "react";
+import type { ReactNode } from "react";
 
 import "@components/Sidebar/Sidebar.css";
 
@@ -11,39 +11,38 @@ export interface ISidebarIconProps {
   children: ReactNode;
 }
 
-const SidebarIcon = forwardRef<HTMLButtonElement, ISidebarIconProps>(
-  function SidebarIcon(props, ref) {
-    const { name, isActive, isSidebarExpanded, onClick, children } = props;
-
-    return (
-      <button
-        {...props}
-        type="button"
-        onClick={() => onClick()}
-        className={`sidebar-background-color-transition flex flex-row align-middle w-full rounded-lg
+const SidebarIcon = ({
+  name,
+  isActive,
+  isSidebarExpanded,
+  onClick,
+  children,
+}: ISidebarIconProps) => {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick()}
+      className={`sidebar-background-color-transition flex flex-row align-middle w-full rounded-lg
         ${isActive ? "bg-gray-700" : "bg-white"} `}
-        ref={ref}
-      >
-        <div className="flex flex-row w-full p-3">
-          <div
-            className={`w-6 h-6 ${
-              isActive ? "text-gray-200" : "text-gray-400"
-            }`}
-          >
-            {children}
-          </div>
+    >
+      <div className="flex flex-row w-full p-3">
+        <div
+          className={`w-6 h-6 ${isActive ? "text-gray-200" : "text-gray-400"}`}
+        >
+          {children}
+        </div>
 
-          <p
-            className={`sidebar-opacity-transition px-3 text-xs font-medium self-center whitespace-nowrap 
+        <p
+          className={`sidebar-opacity-transition px-3 text-xs font-medium self-center whitespace-nowrap 
             ${isActive ? "text-gray-100" : "text-gray-700"}
             `}
-            style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
-          >
-            {name}
-          </p>
-        </div>
-      </button>
-    );
-  }
-);
+          style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
+        >
+          {name}
+        </p>
+      </div>
+    </button>
+  );
+};
+
 export default SidebarIcon;

--- a/src/components/Sidebar/SidebarIcon.tsx
+++ b/src/components/Sidebar/SidebarIcon.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { ReactNode } from "react";
 
 import "@components/Sidebar/Sidebar.css";
+import DefaultTooltip from "../DefaultTooltip";
 
 export interface ISidebarIconProps {
   name: string;
@@ -19,29 +20,35 @@ const SidebarIcon = ({
   children,
 }: ISidebarIconProps) => {
   return (
-    <button
-      type="button"
-      onClick={() => onClick()}
-      className={`sidebar-background-color-transition flex flex-row align-middle w-full rounded-lg
+    <>
+      <DefaultTooltip text={name} deactivated={isSidebarExpanded}>
+        <button
+          type="button"
+          onClick={() => onClick()}
+          className={`sidebar-background-color-transition flex flex-row align-middle w-full rounded-lg
         ${isActive ? "bg-gray-700" : "bg-white"} `}
-    >
-      <div className="flex flex-row w-full p-3">
-        <div
-          className={`w-6 h-6 ${isActive ? "text-gray-200" : "text-gray-400"}`}
         >
-          {children}
-        </div>
+          <div className="flex flex-row w-full p-3">
+            <div
+              className={`w-6 h-6 ${
+                isActive ? "text-gray-200" : "text-gray-400"
+              }`}
+            >
+              {children}
+            </div>
 
-        <p
-          className={`sidebar-opacity-transition px-3 text-xs font-medium self-center whitespace-nowrap 
+            <p
+              className={`sidebar-opacity-transition px-3 text-xs font-medium self-center whitespace-nowrap 
             ${isActive ? "text-gray-100" : "text-gray-700"}
             `}
-          style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
-        >
-          {name}
-        </p>
-      </div>
-    </button>
+              style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
+            >
+              {name}
+            </p>
+          </div>
+        </button>
+      </DefaultTooltip>
+    </>
   );
 };
 

--- a/src/components/Sidebar/SidebarIcon.tsx
+++ b/src/components/Sidebar/SidebarIcon.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import type { ReactNode } from "react";
+import { ReactNode, forwardRef } from "react";
 
 import "@components/Sidebar/Sidebar.css";
 
@@ -11,38 +11,39 @@ export interface ISidebarIconProps {
   children: ReactNode;
 }
 
-const SidebarIcon = ({
-  name,
-  isActive,
-  isSidebarExpanded,
-  onClick,
-  children,
-}: ISidebarIconProps) => {
-  return (
-    <button
-      type="button"
-      onClick={() => onClick()}
-      className={`sidebar-background-color-transition flex flex-row align-middle w-full rounded-lg
-        ${isActive ? "bg-gray-700" : "bg-white"} `}
-    >
-      <div className="flex flex-row w-full p-3">
-        <div
-          className={`w-6 h-6 ${isActive ? "text-gray-200" : "text-gray-400"}`}
-        >
-          {children}
-        </div>
+const SidebarIcon = forwardRef<HTMLButtonElement, ISidebarIconProps>(
+  function SidebarIcon(props, ref) {
+    const { name, isActive, isSidebarExpanded, onClick, children } = props;
 
-        <p
-          className={`sidebar-opacity-transition px-3 text-xs font-medium self-center whitespace-nowrap 
+    return (
+      <button
+        {...props}
+        type="button"
+        onClick={() => onClick()}
+        className={`sidebar-background-color-transition flex flex-row align-middle w-full rounded-lg
+        ${isActive ? "bg-gray-700" : "bg-white"} `}
+        ref={ref}
+      >
+        <div className="flex flex-row w-full p-3">
+          <div
+            className={`w-6 h-6 ${
+              isActive ? "text-gray-200" : "text-gray-400"
+            }`}
+          >
+            {children}
+          </div>
+
+          <p
+            className={`sidebar-opacity-transition px-3 text-xs font-medium self-center whitespace-nowrap 
             ${isActive ? "text-gray-100" : "text-gray-700"}
             `}
-          style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
-        >
-          {name}
-        </p>
-      </div>
-    </button>
-  );
-};
-
+            style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
+          >
+            {name}
+          </p>
+        </div>
+      </button>
+    );
+  }
+);
 export default SidebarIcon;


### PR DESCRIPTION
Add tooltip text to the sidebar icons so that users can understand the icons when the sidebar is collapsed.

closes: #392 

![image](https://github.com/ajmcquilkin/meshtastic-network-management-client/assets/55488549/c0f371e9-50c4-48a5-84f3-d71ede228979)
