### PR TITLE
Added TCP connection persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "redux-logger": "^3.0.6",
     "redux-saga": "^1.2.1",
     "tailwindcss-radix": "^2.8.0",
+    "tauri-plugin-store-api": "github:tauri-apps/tauri-plugin-store#v1",
     "timeago-react": "^3.0.5",
     "tsparticles": "^2.7.1",
     "tsparticles-engine": "^2.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,6 +148,9 @@ dependencies:
   tailwindcss-radix:
     specifier: ^2.8.0
     version: 2.8.0
+  tauri-plugin-store-api:
+    specifier: github:tauri-apps/tauri-plugin-store#v1
+    version: github.com/tauri-apps/tauri-plugin-store/96e2eb3971c981ece96f0a9e47dad14a2d1d2539
   timeago-react:
     specifier: ^3.0.5
     version: 3.0.5(react@18.2.0)
@@ -3036,6 +3039,11 @@ packages:
   /@tauri-apps/api@1.1.0:
     resolution: {integrity: sha512-n13pIqdPd3KtaMmmAcrU7BTfdMtIlGNnfZD0dNX8L4p8dgmuNyikm6JAA+yCpl9gqq6I8x5cV2Y0muqdgD0cWw==}
     engines: {node: '>= 12.22.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
+    dev: false
+
+  /@tauri-apps/api@1.4.0:
+    resolution: {integrity: sha512-Jd6HPoTM1PZSFIzq7FB8VmMu3qSSyo/3lSwLpoapW+lQ41CL5Dow2KryLg+gyazA/58DRWI9vu/XpEeHK4uMdw==}
+    engines: {node: '>= 14.6.0', npm: '>= 6.6.0', yarn: '>= 1.19.1'}
     dev: false
 
   /@tauri-apps/cli-darwin-arm64@1.1.1:
@@ -8059,3 +8067,11 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  github.com/tauri-apps/tauri-plugin-store/96e2eb3971c981ece96f0a9e47dad14a2d1d2539:
+    resolution: {tarball: https://codeload.github.com/tauri-apps/tauri-plugin-store/tar.gz/96e2eb3971c981ece96f0a9e47dad14a2d1d2539}
+    name: tauri-plugin-store-api
+    version: 0.0.0
+    dependencies:
+      '@tauri-apps/api': 1.4.0
+    dev: false

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -64,7 +64,7 @@ checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "app"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -86,6 +86,7 @@ dependencies = [
  "specta",
  "tauri",
  "tauri-build",
+ "tauri-plugin-store",
  "thiserror",
  "time",
  "tokio",
@@ -3519,6 +3520,18 @@ dependencies = [
  "syn 1.0.109",
  "tauri-codegen",
  "tauri-utils",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "0.0.0"
+source = "git+https://github.com/tauri-apps/plugins-workspace?branch=v1#0d0ed7b9075ee21f37d787217fba3ef0784b2449"
+dependencies = [
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "app"
-version = "0.1.0"
-description = "A Tauri App"
-authors = ["you"]
-license = ""
+version = "0.2.0"
+description = "Meshtastic Network Management Client"
+authors = ["Adam McQuilkin"]
+license = "GPL-3.0"
 repository = ""
 default-run = "app"
 edition = "2021"
@@ -25,7 +25,7 @@ defaultdict = "0.13.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.1.1", features = ["cli", "clipboard-write-text", "dialog-message", "http-all", "notification-all", "shell-open", "windows7-compat"] }
+tauri = { version = "1.1.1", features = ["cli", "clipboard-write-text", "dialog-message", "http-all", "notification-all", "path-all", "shell-open", "windows7-compat"] }
 tokio = { version = "1.21.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
@@ -41,6 +41,7 @@ humantime = "2.1.0"
 tokio-util = "0.7.7"
 serial2 = "0.1.7"
 specta = { git = "https://github.com/ajmcquilkin/specta.git", branch = "ajmcquilkin/ts-namespaces", ref = "2ba5af7" }
+tauri-plugin-store = { git = "https://github.com/tauri-apps/plugins-workspace", branch = "v1" }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -110,6 +110,7 @@ fn main() {
     };
 
     tauri::Builder::default()
+        .plugin(tauri_plugin_store::Builder::default().build())
         .setup(|app| {
             match handle_cli_matches(app, &mut inital_autoconnect_state) {
                 Ok(_) => {}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -28,11 +28,12 @@
       "http": {
         "all": true,
         "request": true,
-        "scope": [
-          " http://127.0.0.1:5000/*"
-        ]
+        "scope": [" http://127.0.0.1:5000/*"]
       },
       "notification": {
+        "all": true
+      },
+      "path": {
         "all": true
       },
       "shell": {

--- a/src/features/appConfig/appConfigActions.ts
+++ b/src/features/appConfig/appConfigActions.ts
@@ -1,0 +1,11 @@
+import { createAction } from "@reduxjs/toolkit";
+import type { TcpConnectionMeta } from "@features/appConfig/appConfigSlice";
+
+export const requestFetchLastTcpConnectionMeta = createAction(
+  "@appConfig/fetch-last-tcp-connection-meta"
+);
+
+export const requestPersistLastTcpConnectionMeta =
+  createAction<TcpConnectionMeta | null>(
+    "@appConfig/persist-last-tcp-connection-meta"
+  );

--- a/src/features/appConfig/appConfigSagas.ts
+++ b/src/features/appConfig/appConfigSagas.ts
@@ -1,0 +1,90 @@
+import { all, put, takeEvery } from "redux-saga/effects";
+import { Store } from "tauri-plugin-store-api";
+
+import {
+  requestFetchLastTcpConnectionMeta,
+  requestPersistLastTcpConnectionMeta,
+} from "@features/appConfig/appConfigActions";
+import { appConfigActions } from "@features/appConfig/appConfigSlice";
+import { requestSliceActions } from "@features/requests/requestReducer";
+
+import type { CommandError } from "@utils/errors";
+import {
+  DEFAULT_STORE_FILE_NAME,
+  IPersistedState,
+  PersistedStateKeys,
+  getValueFromPersistedStore,
+  setValueInPersistedStore,
+} from "@utils/persistence";
+
+const defaultStore = new Store(DEFAULT_STORE_FILE_NAME);
+
+function* fetchLastTcpConnectionMetaWorker(
+  action: ReturnType<typeof requestFetchLastTcpConnectionMeta>
+) {
+  try {
+    yield put(requestSliceActions.setRequestPending({ name: action.type }));
+
+    const persistedValue = (yield getValueFromPersistedStore(
+      defaultStore,
+      PersistedStateKeys.LastTcpConnection
+    )) as IPersistedState[PersistedStateKeys.LastTcpConnection];
+
+    yield put(appConfigActions.setLastTcpConnection(persistedValue ?? null));
+
+    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
+  } catch (error) {
+    yield put(
+      requestSliceActions.setRequestFailed({
+        name: action.type,
+        message: (error as CommandError).message,
+      })
+    );
+  }
+}
+
+function* persistLastTcpConnectionMetaWorker(
+  action: ReturnType<typeof requestPersistLastTcpConnectionMeta>
+) {
+  try {
+    yield put(requestSliceActions.setRequestPending({ name: action.type }));
+
+    yield setValueInPersistedStore(
+      defaultStore,
+      PersistedStateKeys.LastTcpConnection,
+      action.payload ?? undefined
+    );
+
+    // Fetch value from store to ensure it was set correctly
+    const persistedValue = (yield getValueFromPersistedStore(
+      defaultStore,
+      PersistedStateKeys.LastTcpConnection
+    )) as IPersistedState[PersistedStateKeys.LastTcpConnection];
+
+    if (JSON.stringify(persistedValue) !== JSON.stringify(action.payload)) {
+      throw new Error("Failed to persist last TCP connection");
+    }
+
+    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
+  } catch (error) {
+    yield put(
+      requestSliceActions.setRequestFailed({
+        name: action.type,
+        message: (error as CommandError).message,
+      })
+    );
+  }
+}
+
+export function* appConfigSaga() {
+  yield all([
+    takeEvery(
+      requestFetchLastTcpConnectionMeta.type,
+      fetchLastTcpConnectionMetaWorker
+    ),
+    takeEvery(
+      requestPersistLastTcpConnectionMeta.type,
+      persistLastTcpConnectionMetaWorker
+    ),
+  ]);
+}

--- a/src/features/appConfig/appConfigSelectors.ts
+++ b/src/features/appConfig/appConfigSelectors.ts
@@ -1,0 +1,7 @@
+import type { RootState } from "@app/store";
+import type { TcpConnectionMeta } from "@features/appConfig/appConfigSlice";
+
+export const selectPersistedTCPConnectionMeta =
+  () =>
+  (state: RootState): TcpConnectionMeta | null =>
+    state.appConfig.lastTcpConnection;

--- a/src/features/appConfig/appConfigSlice.ts
+++ b/src/features/appConfig/appConfigSlice.ts
@@ -1,0 +1,30 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type TcpConnectionMeta = {
+  address: string;
+  port: number;
+};
+
+export interface IAppConfigState {
+  lastTcpConnection: TcpConnectionMeta | null;
+}
+
+export const initialAppConfigState: IAppConfigState = {
+  lastTcpConnection: null,
+};
+
+export const appConfigSlice = createSlice({
+  name: "appConfig",
+  initialState: initialAppConfigState,
+  reducers: {
+    setLastTcpConnection: (
+      state,
+      action: PayloadAction<TcpConnectionMeta | null>
+    ) => {
+      state.lastTcpConnection = action.payload;
+    },
+  },
+});
+
+export const { actions: appConfigActions, reducer: appConfigReducer } =
+  appConfigSlice;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import createSagaMiddleware from "redux-saga";
 import { logger } from "redux-logger";
 
 import { algorithmsReducer } from "@features/algorithms/algorithmsSlice";
+import { appConfigReducer } from "@features/appConfig/appConfigSlice";
 import { configReducer } from "@features/config/configSlice";
 import { connectionReducer } from "@features/connection/connectionSlice";
 import { requestInitializeApplication } from "@features/device/deviceActions";
@@ -18,6 +19,7 @@ const middleware = [sagaMiddleware, logger];
 export const store = configureStore({
   reducer: {
     algorithms: algorithmsReducer,
+    appConfig: appConfigReducer,
     config: configReducer,
     connection: connectionReducer,
     devices: deviceReducer,

--- a/src/store/saga.ts
+++ b/src/store/saga.ts
@@ -1,9 +1,15 @@
 import { all, fork } from "redux-saga/effects";
 
 import { algorithmsSaga } from "@features/algorithms/algorithmsSagas";
+import { appConfigSaga } from "@app/features/appConfig/appConfigSagas";
 import { configSaga } from "@features/config/configSagas";
 import { devicesSaga } from "@features/device/deviceSagas";
 
 export default function* rootSaga() {
-  yield all([fork(algorithmsSaga), fork(configSaga), fork(devicesSaga),]);
+  yield all([
+    fork(algorithmsSaga),
+    fork(appConfigSaga),
+    fork(configSaga),
+    fork(devicesSaga),
+  ]);
 }

--- a/src/utils/persistence.ts
+++ b/src/utils/persistence.ts
@@ -1,0 +1,35 @@
+import type { TcpConnectionMeta } from "@features/appConfig/appConfigSlice";
+import type { Store } from "tauri-plugin-store-api";
+
+export const DEFAULT_STORE_FILE_NAME = "config.bin";
+
+export enum PersistedStateKeys {
+  LastTcpConnection = "lastTcpConnection",
+  OtherKey = "otherKey",
+}
+
+export interface IPersistedState {
+  [PersistedStateKeys.LastTcpConnection]?: TcpConnectionMeta;
+  [PersistedStateKeys.OtherKey]?: string;
+}
+
+export function* setValueInPersistedStore<TKey extends keyof IPersistedState>(
+  store: Store,
+  key: TKey,
+  value: IPersistedState[TKey],
+  save = true
+) {
+  yield store.set(key, value);
+
+  if (save) {
+    yield store.save();
+  }
+}
+
+export function* getValueFromPersistedStore<TKey extends keyof IPersistedState>(
+  store: Store,
+  key: TKey
+) {
+  const val = (yield store.get(key)) as IPersistedState[TKey];
+  return val;
+}


### PR DESCRIPTION
This PR adds persistence infrastructure with the [Tauri Store plugin](https://github.com/tauri-apps/tauri-plugin-store). This plugin allows for the storage of arbitrary JSON by string key. This PR also adds Redux infrastructure for getting and setting these values.

This persistence allows for the storage of the last TCP connection state, meaning the `ConnectPage.tsx` component can save and recall the address and port of the last TCP connection the user attempted.

Closes #420 