### PR TITLE
fix(ui)!: :bug: demo to fix incorrect coordinates when creating waypoint

### DIFF
--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -269,7 +269,7 @@ export const MapView = () => {
         {(lastRightClickLngLat || editingWaypoint) && (
           <CreateWaypointDialog
             // use key prop to force re-render
-            key={`${lastRightClickLngLat?.lat}-${lastRightClickLngLat?.lng}-${Date.now()}`}
+            key={lastRightClickLngLat?.toString()}
             lngLat={lastRightClickLngLat ?? new LngLat(0, 0)}
             closeDialog={() => {
               setEditingWaypoint(null);


### PR DESCRIPTION
As titled

Added key prop to `<CreateWaypointDialog />` for forced re-render/ remount. 
This demo should resolve the issue with incorrect coordinates (`lastRightClickLngLat`).

Fix #487