### PR TITLE
[Cleanup] Clean up warnings and unused code

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -165,7 +165,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "specta 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82)",
+ "specta 1.0.3",
  "tauri",
  "tauri-build",
  "tauri-plugin-cli",
@@ -2869,8 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "meshtastic"
-version = "0.1.6"
-source = "git+https://github.com/meshtastic/rust.git?rev=6057294aa6cfa979033299f7f02cfe6ceafddeda#6057294aa6cfa979033299f7f02cfe6ceafddeda"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f474b7f41f74f2b5d46aec08735d1e426efd3ddb927b0cec9fea77367d02e0"
 dependencies = [
  "bluez-async",
  "btleplug",
@@ -2883,7 +2884,8 @@ dependencies = [
  "rand 0.9.1",
  "serde",
  "serde_json",
- "specta 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d)",
+ "specta 2.0.0-rc.22",
+ "specta-typescript",
  "thiserror 2.0.12",
  "tokio",
  "tokio-serial",
@@ -2962,9 +2964,9 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.8.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nalgebra"
@@ -3923,8 +3925,8 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac6c3320f9abac597dcbc668774ef006702672474aad53c6d596b62e487b40b1"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.13.0",
+ "heck 0.4.1",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -3961,12 +3963,13 @@ dependencies = [
 
 [[package]]
 name = "protoc-bin-vendored"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd89a830d0eab2502c81a9b8226d446a52998bb78e5e33cb2637c0cdd6068d99"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
 dependencies = [
  "protoc-bin-vendored-linux-aarch_64",
  "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
  "protoc-bin-vendored-linux-x86_32",
  "protoc-bin-vendored-linux-x86_64",
  "protoc-bin-vendored-macos-aarch_64",
@@ -3976,45 +3979,51 @@ dependencies = [
 
 [[package]]
 name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f563627339f1653ea1453dfbcb4398a7369b768925eb14499457aeaa45afe22c"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
 
 [[package]]
 name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5025c949a02cd3b60c02501dd0f348c16e8fff464f2a7f27db8a9732c608b746"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
 
 [[package]]
 name = "protoc-bin-vendored-linux-x86_32"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9500ce67d132c2f3b572504088712db715755eb9adf69d55641caa2cb68a07"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
 
 [[package]]
 name = "protoc-bin-vendored-linux-x86_64"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5462592380cefdc9f1f14635bcce70ba9c91c1c2464c7feb2ce564726614cc41"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
 
 [[package]]
 name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c637745681b68b4435484543667a37606c95ddacf15e917710801a0877506030"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
 
 [[package]]
 name = "protoc-bin-vendored-macos-x86_64"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38943f3c90319d522f94a6dfd4a134ba5e36148b9506d2d9723a82ebc57c8b55"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
 
 [[package]]
 name = "protoc-bin-vendored-win32"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psl-types"
@@ -5066,7 +5075,7 @@ dependencies = [
 [[package]]
 name = "specta"
 version = "1.0.3"
-source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d#6a8731d168376e28e163dd9cd328055b11d1af82"
+source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82#6a8731d168376e28e163dd9cd328055b11d1af82"
 dependencies = [
  "chrono",
  "ctor 0.1.26",
@@ -5076,31 +5085,26 @@ dependencies = [
  "paste",
  "serde",
  "serde_json",
- "specta-macros 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d)",
+ "specta-macros 1.0.3",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "specta"
-version = "1.0.3"
-source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82#6a8731d168376e28e163dd9cd328055b11d1af82"
+version = "2.0.0-rc.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7f01e9310a820edd31c80fde3cae445295adde21a3f9416517d7d65015b971"
 dependencies = [
  "chrono",
- "ctor 0.1.26",
- "document-features",
- "indoc",
- "once_cell",
- "paste",
- "serde",
- "serde_json",
- "specta-macros 1.0.3 (git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82)",
+ "ctor 0.2.9",
+ "specta-macros 2.0.0-rc.18",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "specta-macros"
 version = "1.0.3"
-source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d#6a8731d168376e28e163dd9cd328055b11d1af82"
+source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82#6a8731d168376e28e163dd9cd328055b11d1af82"
 dependencies = [
  "Inflector",
  "itertools 0.10.5",
@@ -5112,15 +5116,35 @@ dependencies = [
 
 [[package]]
 name = "specta-macros"
-version = "1.0.3"
-source = "git+https://github.com/ajmcquilkin/specta.git?rev=6a8731d168376e28e163dd9cd328055b11d1af82#6a8731d168376e28e163dd9cd328055b11d1af82"
+version = "2.0.0-rc.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0074b9e30ed84c6924eb63ad8d2fe71cdc82628525d84b1fcb1f2fd40676517"
 dependencies = [
  "Inflector",
- "itertools 0.10.5",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "termcolor",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "specta-serde"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77216504061374659e7245eac53d30c7b3e5fe64b88da97c753e7184b0781e63"
+dependencies = [
+ "specta 2.0.0-rc.22",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "specta-typescript"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3220a0c365e51e248ac98eab5a6a32f544ff6f961906f09d3ee10903a4f52b2d"
+dependencies = [
+ "specta 2.0.0-rc.22",
+ "specta-serde",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,7 +38,6 @@ tauri-plugin-store = "2"
 tokio-serial = "5.4.4"
 tauri-plugin-log = { features = ["colored"] , version = "2" }
 chrono = { version = "0.4.34", features = ["serde"] }
-meshtastic = { git = "https://github.com/meshtastic/rust.git", rev = "6057294aa6cfa979033299f7f02cfe6ceafddeda", features = ["ts-gen", "bluetooth-le"] }
 specta = { git = "https://github.com/ajmcquilkin/specta.git", rev = "6a8731d168376e28e163dd9cd328055b11d1af82", version = "1.0.3", features = ["chrono"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
@@ -48,6 +47,7 @@ tauri-plugin-http = "2"
 tauri-plugin-cli = "2"
 btleplug = "0.11.8"
 uuid = "1.17.0"
+meshtastic = { version = "0.1.7", features = ["bluetooth-le", "gen", "ts-gen"] }
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/api/primitives/radio.rs
+++ b/src-tauri/src/api/primitives/radio.rs
@@ -1,5 +1,2 @@
-use serde::{Deserialize, Serialize};
-use specta::Type;
-
 // Re-export types from meshtastic protobufs
 pub use meshtastic::protobufs::{Config, User};

--- a/src-tauri/src/device/helpers.rs
+++ b/src-tauri/src/device/helpers.rs
@@ -1,8 +1,6 @@
 use rand::{distributions::Standard, prelude::Distribution, Rng};
 use std::time::UNIX_EPOCH;
 
-use super::MeshDevice;
-
 pub fn get_current_time_u32() -> u32 {
     std::time::SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -18,24 +16,6 @@ where
 {
     let mut rng = rand::thread_rng();
     rng.gen::<T>()
-}
-
-pub fn get_node_user_name(device: &mut MeshDevice, node_id: &u32) -> Option<String> {
-    let db_node = device.nodes.get(node_id)?;
-    let db_user = db_node.user.as_ref()?;
-
-    Some(db_user.long_name.clone())
-}
-
-pub fn get_channel_name(device: &mut MeshDevice, channel_id: &u32) -> Option<String> {
-    let db_channel = device.channels.get(channel_id)?;
-    let db_channel_settings = db_channel.config.settings.as_ref()?;
-
-    if db_channel_settings.name.is_empty() {
-        return format!("Channel {}", db_channel.config.index).into();
-    }
-
-    Some(db_channel_settings.name.clone())
 }
 
 /// Converts a mesh location field (e.g., latitude) from

--- a/src-tauri/src/device/mod.rs
+++ b/src-tauri/src/device/mod.rs
@@ -184,9 +184,9 @@ impl From<protobufs::Position> for NormalizedPosition {
             longitude: normalize_location_field(position.longitude_i.unwrap_or_default()),
             altitude: position.altitude.unwrap_or_default(),
             time: position.time,
-            location_source: protobufs::position::LocSource::from_i32(position.location_source)
+            location_source: protobufs::position::LocSource::try_from(position.location_source)
                 .expect("Could not convert i32 to LocSource"),
-            altitude_source: protobufs::position::AltSource::from_i32(position.altitude_source)
+            altitude_source: protobufs::position::AltSource::try_from(position.altitude_source)
                 .expect("Could not convert i32 to AltSource"),
             timestamp: position.timestamp,
             timestamp_millis_adjust: position.timestamp_millis_adjust,

--- a/src-tauri/src/domains/mesh.rs
+++ b/src-tauri/src/domains/mesh.rs
@@ -5,12 +5,11 @@ use crate::api::contracts::mesh::SendTextResponse;
 use crate::api::contracts::mesh::SendWaypointRequest;
 use crate::api::contracts::mesh::SendWaypointResponse;
 use crate::device::helpers::convert_location_field_to_protos;
-use crate::device::NormalizedWaypoint;
 use crate::ipc::events;
 use crate::ipc::CommandError;
-use crate::state::{self, DeviceKey};
+use crate::state;
 
-use log::{debug, trace};
+use log::trace;
 use meshtastic::packet::PacketDestination;
 use meshtastic::protobufs;
 use meshtastic::types::MeshChannel;

--- a/src-tauri/src/ipc/commands/radio.rs
+++ b/src-tauri/src/ipc/commands/radio.rs
@@ -8,12 +8,10 @@ use crate::domains::radio::{
     handle_commit_configuration_transaction, handle_start_configuration_transaction,
     handle_update_device_config, handle_update_device_config_bulk, handle_update_device_user,
 };
-use crate::ipc::events;
 use crate::ipc::CommandError;
 use crate::state;
 
 use log::debug;
-use log::trace;
 
 #[tauri::command]
 pub async fn update_device_config(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,21 +12,9 @@ mod ipc;
 mod packet_api;
 mod state;
 
-use log::{info, LevelFilter};
-use specta::{
-    export::ts_with_cfg,
-    ts::{BigIntExportBehavior, ExportConfiguration, ModuleExportBehavior, TsExportError},
-};
+use log::LevelFilter;
 use tauri::Manager;
 use tauri_plugin_log::{fern::colors::ColoredLevelConfig, Target, TargetKind};
-
-fn export_ts_types(file_path: &str) -> Result<(), TsExportError> {
-    let ts_export_config = ExportConfiguration::default()
-        .bigint(BigIntExportBehavior::String)
-        .modules(ModuleExportBehavior::Enabled);
-
-    ts_with_cfg(file_path, &ts_export_config)
-}
 
 const LOG_LEVEL: LevelFilter = LevelFilter::Debug;
 

--- a/src-tauri/src/packet_api/handlers/mod.rs
+++ b/src-tauri/src/packet_api/handlers/mod.rs
@@ -10,7 +10,6 @@ pub enum DeviceUpdateError {
     DecodeFailure(String),
     GeneralFailure(String),
     EventDispatchFailure(String),
-    NotificationDispatchFailure(String),
 }
 
 impl fmt::Display for DeviceUpdateError {
@@ -43,12 +42,6 @@ impl fmt::Display for DeviceUpdateError {
                 f.write_fmt(format_args!(
                     "Failed to dispatch device to client:\n{}",
                     dispatch_error
-                ))?;
-            }
-            DeviceUpdateError::NotificationDispatchFailure(ref notification_error) => {
-                f.write_fmt(format_args!(
-                    "Failed to send system-level notification:\n{}",
-                    notification_error
                 ))?;
             }
         }

--- a/src-tauri/src/packet_api/mod.rs
+++ b/src-tauri/src/packet_api/mod.rs
@@ -29,7 +29,7 @@ impl<R: tauri::Runtime> MeshPacketApi<R> {
         }
     }
 
-    pub fn get_locked_graph(&self) -> LockResult<std::sync::MutexGuard<MeshGraph>> {
+    pub fn get_locked_graph<'a>(&'a self) -> LockResult<std::sync::MutexGuard<'a, MeshGraph>> {
         self.graph_arc.lock()
     }
 }

--- a/src/components/config/device/BluetoothConfigPage.tsx
+++ b/src/components/config/device/BluetoothConfigPage.tsx
@@ -47,11 +47,11 @@ export const BluetoothConfigPage = ({
   const editedConfig = useSelector(selectEditedRadioConfig());
 
   const [bluetoothDisabled, setBluetoothDisabled] = useState(
-    !device?.config.bluetooth?.enabled ?? true,
+    device?.config.bluetooth?.enabled ?? true,
   );
 
   const [fixedPinDisabled, setFixedPinDisabled] = useState(
-    device?.config.bluetooth?.mode !== 1 ?? true,
+    device?.config.bluetooth?.mode !== 1,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/device/LoRaConfigPage.tsx
+++ b/src/components/config/device/LoRaConfigPage.tsx
@@ -52,7 +52,7 @@ export const LoRaConfigPage = ({ className = "" }: ILoRaConfigPageProps) => {
   const editedConfig = useSelector(selectEditedRadioConfig());
 
   const [useModemPreset, setUseModemPreset] = useState(
-    device?.config.lora?.modemPreset ?? false,
+    !!device?.config.lora?.modemPreset,
   );
 
   const [txEnabled, setTxEnabled] = useState(

--- a/src/components/config/device/LoRaConfigPage.tsx
+++ b/src/components/config/device/LoRaConfigPage.tsx
@@ -52,7 +52,7 @@ export const LoRaConfigPage = ({ className = "" }: ILoRaConfigPageProps) => {
   const editedConfig = useSelector(selectEditedRadioConfig());
 
   const [useModemPreset, setUseModemPreset] = useState(
-    !(device?.config.lora?.modemPreset ?? false),
+    device?.config.lora?.modemPreset ?? false,
   );
 
   const [txEnabled, setTxEnabled] = useState(

--- a/src/components/config/device/NetworkConfigPage.tsx
+++ b/src/components/config/device/NetworkConfigPage.tsx
@@ -46,11 +46,11 @@ export const NetworkConfigPage = ({
   const editedConfig = useSelector(selectEditedRadioConfig());
 
   const [wifiDisabled, setWifiDisabled] = useState(
-    !(device?.config.network?.wifiEnabled ?? true),
+    device?.config.network?.wifiEnabled ?? true,
   );
 
   const [ethDisabled, setEthDisabled] = useState(
-    !(device?.config.network?.ethEnabled ?? true),
+    device?.config.network?.ethEnabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/device/PositionConfigPage.tsx
+++ b/src/components/config/device/PositionConfigPage.tsx
@@ -57,11 +57,11 @@ export const PositionConfigPage = ({
   const editedConfig = useSelector(selectEditedRadioConfig());
 
   const [gpsDisabled, setGpsDisabled] = useState(
-    !device?.config.position?.gpsEnabled ?? true,
+    device?.config.position?.gpsEnabled ?? true,
   );
 
   const [fixedPositionDisabled, setFixedPositionDisabled] = useState(
-    !device?.config.position?.fixedPosition ?? true,
+    device?.config.position?.fixedPosition ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/AudioConfigPage.tsx
+++ b/src/components/config/module/AudioConfigPage.tsx
@@ -47,7 +47,7 @@ const AudioConfigPage = ({ className = "" }: IAudioConfigPageProps) => {
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [codec2Disabled, setCodec2Disabled] = useState(
-    !(device?.moduleConfig.audio?.codec2Enabled ?? true),
+    device?.moduleConfig.audio?.codec2Enabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/CannedMessageConfigPage.tsx
+++ b/src/components/config/module/CannedMessageConfigPage.tsx
@@ -51,7 +51,7 @@ export const CannedMessageConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [moduleDisabled, setModuleDisabled] = useState(
-    !device?.moduleConfig.cannedMessage?.enabled ?? true,
+    device?.moduleConfig.cannedMessage?.enabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/ExternalNotificationConfigPage.tsx
+++ b/src/components/config/module/ExternalNotificationConfigPage.tsx
@@ -50,15 +50,15 @@ export const ExternalNotificationConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [moduleDisabled, setModuleDisabled] = useState(
-    !device?.moduleConfig.externalNotification?.enabled ?? true,
+    device?.moduleConfig.externalNotification?.enabled ?? true,
   );
 
   const [bellAlertsDisabled, setBellAlertsDisabled] = useState(
-    !device?.moduleConfig.externalNotification?.alertBell ?? true,
+    device?.moduleConfig.externalNotification?.alertBell ?? true,
   );
 
   const [messageAlertsDisabled, setMessageAlertsDisabled] = useState(
-    !device?.moduleConfig.externalNotification?.alertMessage ?? true,
+    device?.moduleConfig.externalNotification?.alertMessage ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/MQTTConfigPage.tsx
+++ b/src/components/config/module/MQTTConfigPage.tsx
@@ -43,7 +43,7 @@ export const MQTTConfigPage = ({ className = "" }: IMQTTConfigPageProps) => {
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [moduleDisabled, setModuleDisabled] = useState(
-    !device?.moduleConfig.mqtt?.enabled ?? true,
+    device?.moduleConfig.mqtt?.enabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/RangeTestConfigPage.tsx
+++ b/src/components/config/module/RangeTestConfigPage.tsx
@@ -46,7 +46,7 @@ export const RangeTestConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [moduleDisabled, setModuleDisabled] = useState(
-    !device?.moduleConfig.rangeTest?.enabled ?? true,
+    device?.moduleConfig.rangeTest?.enabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/RemoteHardwareConfigPage.tsx
+++ b/src/components/config/module/RemoteHardwareConfigPage.tsx
@@ -45,7 +45,7 @@ export const RemoteHardwareConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   // const [moduleDisabled, setModuleDisabled] = useState(
-  //   !device?.moduleConfig.remoteHardware?.enabled ?? true
+  //   device?.moduleConfig.remoteHardware?.enabled ?? true
   // );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/SerialModuleConfigPage.tsx
+++ b/src/components/config/module/SerialModuleConfigPage.tsx
@@ -50,7 +50,7 @@ export const SerialModuleConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [moduleDisabled, setModuleDisabled] = useState(
-    !device?.moduleConfig.serial?.enabled ?? true,
+    device?.moduleConfig.serial?.enabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/StoreAndForwardConfigPage.tsx
+++ b/src/components/config/module/StoreAndForwardConfigPage.tsx
@@ -48,7 +48,7 @@ export const StoreAndForwardConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [moduleDisabled, setModuleDisabled] = useState(
-    !device?.moduleConfig.serial?.enabled ?? true,
+    device?.moduleConfig.serial?.enabled ?? true,
   );
 
   const defaultValues = useMemo(

--- a/src/components/config/module/TelemetryConfigPage.tsx
+++ b/src/components/config/module/TelemetryConfigPage.tsx
@@ -50,11 +50,11 @@ export const TelemetryConfigPage = ({
   const editedConfig = useSelector(selectEditedModuleConfig());
 
   const [airQualityDisabled, setAirQualityDisabled] = useState(
-    !device?.moduleConfig.telemetry?.airQualityEnabled ?? true,
+    device?.moduleConfig.telemetry?.airQualityEnabled ?? true,
   );
 
   const [envMeasurementDisabled, setEnvMeasurementDisabled] = useState(
-    !device?.moduleConfig.telemetry?.environmentMeasurementEnabled ?? true,
+    device?.moduleConfig.telemetry?.environmentMeasurementEnabled ?? true,
   );
 
   const defaultValues = useMemo(


### PR DESCRIPTION
This PR does the following:
- Bumps the version of the `meshtastic` crate from `0.1.6` to `0.1.7`
- Cleans up all console-displayed errors when running `pnpm run ui:dev`
- Cleans up all console-displayed errors when running `pnpm run rust:dev`