### PR TITLE
fix: resolve BLE device discovery serialization and Redux state issues

### DIFF
--- a/src/api/connection.ts
+++ b/src/api/connection.ts
@@ -25,9 +25,14 @@ export const requestAutoConnectPort = async () => {
 export const getAllBluetooth = async () => {
   const response = (await invoke("get_all_bluetooth", {
     request: {},
-  })) as { candidates: string[] };
+  })) as { candidates: Array<{ 0: string }> | string[] };
 
-  return response.candidates;
+  // Handle both formats: newtype struct { 0: string } and plain strings
+  return Array.isArray(response.candidates)
+    ? response.candidates.map((candidate: any) =>
+        typeof candidate === "string" ? candidate : candidate[0],
+      )
+    : [];
 };
 
 export const getAllSerialPorts = async () => {

--- a/src/features/device/api.ts
+++ b/src/features/device/api.ts
@@ -63,11 +63,17 @@ export const useDeviceApi = () => {
     const TYPE = DeviceApiActions.GetAvailableBluetoothDevices;
 
     await trackRequestOperation(TYPE, dispatch, async () => {
-      const bluetoothDevices = await backendConnectionApi.getAllBluetooth();
+      try {
+        const bluetoothDevices = await backendConnectionApi.getAllBluetooth();
 
-      dispatch(
-        deviceSliceActions.setAvailableBluetoothDevices(bluetoothDevices),
-      );
+        dispatch(
+          deviceSliceActions.setAvailableBluetoothDevices(bluetoothDevices),
+        );
+      } catch (e) {
+        // Handle BLE scanning errors gracefully
+        console.error("Failed to scan for Bluetooth devices:", e);
+        dispatch(deviceSliceActions.setAvailableBluetoothDevices([]));
+      }
     });
   };
 

--- a/src/features/device/slice.ts
+++ b/src/features/device/slice.ts
@@ -63,6 +63,10 @@ export const deviceSlice = createSlice({
     setAutoConnectPort: (state, action: PayloadAction<string | null>) => {
       state.autoConnectPort = action.payload;
     },
+
+    setAutoConnectBluetooth: (state, action: PayloadAction<string | null>) => {
+      state.autoConnectBluetooth = action.payload;
+    },
   },
 });
 


### PR DESCRIPTION
- Fix BluetoothConnectionCandidate deserialization in TypeScript The Rust backend returns BluetoothConnectionCandidate as a newtype struct, but TypeScript was casting it as plain strings. Added proper mapping to extract the string value from the struct.

- Add error handling for BLE scan failures Wrapped the getAvailableBluetoothDevices call in try-catch to handle BLE scanning errors gracefully and dispatch empty device list on failure.

- Add missing setAutoConnectBluetooth Redux action The action was being called in the codebase but wasn't defined in the device slice reducer. Added the reducer to properly manage autoconnect Bluetooth state.


Should resolve #534 but I don't have a PC so unable to validate on Windows. Validation passes on MacOS.